### PR TITLE
Add support for linear tensor accessors in CUDA and C backend

### DIFF
--- a/stdlib/c/compile.mc
+++ b/stdlib/c/compile.mc
@@ -1211,6 +1211,18 @@ lang MExprCCompile = MExprCCompileBase + MExprTensorCCompile
       lhs = CEBinOp {op = COSubScript {}, lhs = data, rhs = idx},
       rhs = get args 2
     }
+  | CTensorLinearGetExn _ ->
+    let idx = last args in
+    let data = CEMember {lhs = head args, id = _tensorDataKey} in
+    CEBinOp {op = COSubScript {}, lhs = data, rhs = idx}
+  | CTensorLinearSetExn _ ->
+    let idx = get args 1 in
+    let data = CEMember {lhs = head args, id = _tensorDataKey} in
+    CEBinOp {
+      op = COAssign (),
+      lhs = CEBinOp {op = COSubScript {}, lhs = data, rhs = idx},
+      rhs = get args 2
+    }
   | CTensorRank _ -> CEMember {lhs = head args, id = _tensorRankKey}
   | CTensorShape _ -> tensorShapeCall (head args)
 

--- a/stdlib/cuda/well-formed.mc
+++ b/stdlib/cuda/well-formed.mc
@@ -206,7 +206,8 @@ lang CudaWellFormed = WellFormed + CudaPMExprAst + CudaPMExprPrettyPrint
   | CNeqf _ -> true
   | CPrint _ | CDPrint _ | CInt2float _ | CFloorfi _ | CGet _ | CLength _
   | CFoldl _ | CError _ -> true
-  | CTensorGetExn _ | CTensorSetExn _ | CTensorRank _ | CTensorShape _
+  | CTensorGetExn _ | CTensorSetExn _ | CTensorLinearGetExn _
+  | CTensorLinearSetExn _ | CTensorRank _ | CTensorShape _
   | CTensorSliceExn _ | CTensorSubExn _ -> true
   | _ -> false
 


### PR DESCRIPTION
Still testing this out, having some problems getting tensors to work in the accelerate context.