### PR TITLE
Add error checks after CUDA statements

### DIFF
--- a/src/main/accelerate.mc
+++ b/src/main/accelerate.mc
@@ -2,6 +2,7 @@ include "c/ast.mc"
 include "c/pprint.mc"
 include "cuda/compile.mc"
 include "cuda/constant-app.mc"
+include "cuda/gpu-utils.mc"
 include "cuda/lang-fix.mc"
 include "cuda/pmexpr-ast.mc"
 include "cuda/pmexpr-compile.mc"
@@ -339,6 +340,7 @@ let buildCuda : Options -> String -> [String] -> [String] -> [Top] -> CudaProg
     ("program.ml", pprintOCamlTops ocamlTops),
     ("program.mli", ""),
     ("gpu.cu", pprintCudaAst cudaProg),
+    ("gpu-utils.cu", gpu_utils_code),
     ("dune", dunefile),
     ("dune-project", "(lang dune 2.0)"),
     ("Makefile", makefile)];

--- a/stdlib/cuda/compile.mc
+++ b/stdlib/cuda/compile.mc
@@ -12,6 +12,7 @@ let _cudaFree = nameNoSym "cudaFree"
 let _cudaDeviceSynchronize = nameNoSym "cudaDeviceSynchronize"
 let _malloc = nameNoSym "malloc"
 let _free = nameNoSym "free"
+let _GPU_UTILS_CHECK_CUDA_ERROR = _getIdentExn "GPU_UTILS_CHECK_CUDA_ERROR"
 
 let cudaIncludes = concat cIncludes []
 

--- a/stdlib/cuda/compile.mc
+++ b/stdlib/cuda/compile.mc
@@ -12,7 +12,7 @@ let _cudaFree = nameNoSym "cudaFree"
 let _cudaDeviceSynchronize = nameNoSym "cudaDeviceSynchronize"
 let _malloc = nameNoSym "malloc"
 let _free = nameNoSym "free"
-let _GPU_UTILS_CHECK_CUDA_ERROR = _getIdentExn "GPU_UTILS_CHECK_CUDA_ERROR"
+let _GPU_UTILS_CHECK_CUDA_ERROR = nameNoSym "GPU_UTILS_CHECK_CUDA_ERROR"
 
 let cudaIncludes = concat cIncludes []
 

--- a/stdlib/cuda/gpu-utils.mc
+++ b/stdlib/cuda/gpu-utils.mc
@@ -12,6 +12,6 @@ void gpu_utils_checkCudaErr(const char *file, int line)
     }
 }
 
-#define GPU_UTILS_CHECK_CUDA_ERROR() \
+#define GPU_UTILS_CHECK_CUDA_ERROR() \\
         gpu_utils_checkCudaErr(__FILE__, __LINE__)
 "

--- a/stdlib/cuda/gpu-utils.mc
+++ b/stdlib/cuda/gpu-utils.mc
@@ -2,12 +2,13 @@
 
 let gpu_utils_code = "
 #include <stdlib.h>
+#include <stdio.h>
 
 void gpu_utils_checkCudaErr(const char *file, int line)
 {
     cudaError_t err = cudaGetLastError();
     if (err != cudaSuccess) {
-        fprintf(stderr, \"%s:%d: received cuda error: \", cudaGetErrorString(err));
+        fprintf(stderr, \"\\n%s:%d: received cuda error: %s\\n\", file, line, cudaGetErrorString(err));
         exit(1);
     }
 }

--- a/stdlib/cuda/gpu-utils.mc
+++ b/stdlib/cuda/gpu-utils.mc
@@ -1,0 +1,17 @@
+-- defines the code for the gpu-utils.cu file
+
+let gpu_utils_code = "
+#include <stdlib.h>
+
+void gpu_utils_checkCudaErr(const char *file, int line)
+{
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        fprintf(stderr, \"%s:%d: received cuda error: \", cudaGetErrorString(err));
+        exit(1);
+    }
+}
+
+#define GPU_UTILS_CHECK_CUDA_ERROR() \
+        gpu_utils_checkCudaErr(__FILE__, __LINE__)
+"

--- a/stdlib/cuda/intrinsics/loop-kernel.mc
+++ b/stdlib/cuda/intrinsics/loop-kernel.mc
@@ -97,11 +97,15 @@ lang CudaLoopKernelIntrinsic = CudaIntrinsic + CudaPMExprAst
       gridSize = CEVar {id = nblocksId},
       blockSize = CEVar {id = tpbId},
       args = cons t.n args}} in
+    let errorCheckStmt = CSExpr {expr = CEApp {
+        fun = _GPU_UTILS_CHECK_CUDA_ERROR,
+        args = []
+      }} in
     let deviceSynchronizeStmt = CSExpr {expr = CEApp {
       fun = _cudaDeviceSynchronize, args = []}} in
 
     let stmts =
-      [ iterInitStmt, tpbStmt, nblocksStmt, kernelLaunchStmt
-      , deviceSynchronizeStmt ] in
+      [ iterInitStmt, tpbStmt, nblocksStmt, kernelLaunchStmt, errorCheckStmt,
+      , deviceSynchronizeStmt, errorCheckStmt ] in
     (kernelTop, CSComp {stmts = stmts})
 end

--- a/stdlib/cuda/intrinsics/loop-kernel.mc
+++ b/stdlib/cuda/intrinsics/loop-kernel.mc
@@ -105,7 +105,7 @@ lang CudaLoopKernelIntrinsic = CudaIntrinsic + CudaPMExprAst
       fun = _cudaDeviceSynchronize, args = []}} in
 
     let stmts =
-      [ iterInitStmt, tpbStmt, nblocksStmt, kernelLaunchStmt, errorCheckStmt,
+      [ iterInitStmt, tpbStmt, nblocksStmt, kernelLaunchStmt, errorCheckStmt
       , deviceSynchronizeStmt, errorCheckStmt ] in
     (kernelTop, CSComp {stmts = stmts})
 end

--- a/stdlib/pmexpr/wrapper.mc
+++ b/stdlib/pmexpr/wrapper.mc
@@ -22,7 +22,7 @@ let _genCWrapperNames = lam.
     "cudaFree", "cudaMemcpy", "cudaDeviceSynchronize",
     "cudaMemcpyHostToDevice", "cudaMemcpyDeviceToHost", "Caml_ba_array_val",
     "Caml_ba_data_val", "caml_ba_alloc", "CAML_BA_CAML_INT", "CAML_BA_FLOAT64",
-    "CAML_BA_C_LAYOUT", "GPU_UTILS_CHECK_CUDA_ERROR"]
+    "CAML_BA_C_LAYOUT"]
   in
   mapFromSeq
     cmpString

--- a/stdlib/pmexpr/wrapper.mc
+++ b/stdlib/pmexpr/wrapper.mc
@@ -22,7 +22,7 @@ let _genCWrapperNames = lam.
     "cudaFree", "cudaMemcpy", "cudaDeviceSynchronize",
     "cudaMemcpyHostToDevice", "cudaMemcpyDeviceToHost", "Caml_ba_array_val",
     "Caml_ba_data_val", "caml_ba_alloc", "CAML_BA_CAML_INT", "CAML_BA_FLOAT64",
-    "CAML_BA_C_LAYOUT"]
+    "CAML_BA_C_LAYOUT", "GPU_UTILS_CHECK_CUDA_ERROR"]
   in
   mapFromSeq
     cmpString


### PR DESCRIPTION
Adds a macro `GPU_UTILS_CHECK_CUDA_ERROR` into a compantion file "gpu-utils.cu" that is hardcoded as a string. A function call to this macro is added after each significant cuda operation.